### PR TITLE
Add instruction to install by homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 BitBar (by [Mat Ryer - @matryer](https://twitter.com/matryer)) lets you put the output from any script/program in your Mac OS X Menu Bar.
 
-  * [Download latest BitBar release](https://github.com/matryer/bitbar/releases/latest) - requires Mac OS X Lion or newer (>= 10.7)
+  * [Download latest BitBar release](https://github.com/matryer/bitbar/releases/latest) - requires Mac OS X Lion or newer (>= 10.7)  
+    Alternatively, install it by homebrew with `brew cask install bitbar`.
   * [Visit the app homepage at https://getbitbar.com](https://getbitbar.com) to install plugins
   * [Get started](#get-started) and [installing plugins](#installing-plugins)
 


### PR DESCRIPTION
Since this package has already included in [homebrew cask bitbar](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/bitbar.rb) for a few years, maybe we can give instructions of installing by homebrew.
IMO I find it easier to setup.